### PR TITLE
Fixed squishing expense text, headers for expenses, places, calendar

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -7,19 +7,26 @@
 @import 'hamburger-menu';
 @import 'month-card';
 
-h1,h2, h3, h4 {
-    margin: 1rem auto;
+h1,
+h2,
+h3,
+h4 {
+  margin: 1rem auto;
 }
 
-h5, h6 {
-    margin: 0.5rem auto;
+h5,
+h6 {
+  margin: 0.5rem auto;
 }
 
 .categories-header {
-    background-color: $primary-green;
-    color: $white;
-    border-bottom-left-radius: $font-size-base * 1.5;
-    border-bottom-right-radius: $font-size-base * 1.5;
-    height: 180px;
-    display:flexbox;
+  background-color: $primary-green;
+  color: $white;
+  border-bottom-left-radius: $font-size-base * 1.5;
+  border-bottom-right-radius: $font-size-base * 1.5;
+  height: 180px;
+  display: flexbox;
+  &.blue {
+    background-color: $primary-blue;
   }
+}

--- a/app/views/budgets/_form.html.erb
+++ b/app/views/budgets/_form.html.erb
@@ -1,4 +1,6 @@
-<%= render 'components/header', path: expense_type_budgets_path %>
+<div class="categories-header">
+    <%= render 'components/header', path: expense_type_budgets_path %>
+</div>
 <div class="row mx-auto flex-column">
     <div class="col my-3">
         <h5><%= budget.id ? "Update #{@expense_type.name} budget" : "Add a new #{@expense_type.name} budget"%></h5>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -1,4 +1,9 @@
-<%= render 'components/header', path: expense_types_path %>
+<div class="categories-header">
+    <%= render 'components/header', path: expense_types_path %>
+    <div class="row">
+        <h3 class="categories-text  mx-auto">Monthly Budgets</h3>
+    </div>
+</div>
 <div class="row mx-2">
     <% if @budgets.length.zero? %>
     <div class="no-expense-container mx-auto mt-5">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,6 @@
-<%= render 'components/header', path: events_path %>
+<div class="categories-header">
+    <%= render 'components/header', path: events_path %>
+</div>
 <div class="row mx-2 flex-column mt-3">
     <div class="col my-3">
         <h5><%= event.id ? "Update event" : "Add a new event"%></h5>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,14 +1,14 @@
 <div class="categories-header">
     <%= render 'components/header', path: root_path %>
-    <h3 class="categories-text">
-        Calendar
+    <div class="row">
+        <h3 class="categories-text  mx-auto">Calendar</h3>
+    </div>
 </div>
-    </h3>
 <div class="calendar-main">
     <% if params[:month] %>
-        <%= render "month", events: @monthly_events %>
+    <%= render "month", events: @monthly_events %>
     <% else %>
-        <%= render "week", events: @weekly_events %>
+    <%= render "week", events: @weekly_events %>
     <% end %>
-        <%= render 'components/fab', path: new_event_path %>
+    <%= render 'components/fab', path: new_event_path %>
 </div>

--- a/app/views/expense_types/index.html.erb
+++ b/app/views/expense_types/index.html.erb
@@ -1,9 +1,9 @@
 <div class="categories-header">
     <%= render 'components/header', path: root_path %>
-    <h3 class="categories-text">
-        Expenses
+    <div class="row">
+        <h3 class="categories-text  mx-auto">Expense Categories</h3>
+    </div>
 </div>
-</h3>
 <div class="expenses-main"></div>
 <% @expense_types.each do |expense_type| %>
 <div class="row card my-2 shadow border flex-row mx-auto">
@@ -25,7 +25,7 @@
                 <% end %>
             </div>
             <div class="row">
-                <div class="col expense-type-links">
+                <div class="col-6 expense-type-links">
                     <div class="row">
                         <span class="text-muted mr-1">Actuals</span> - <span class="ml-1">$<%=expense_type.expenses.sum(:amount)%></span>
                     </div>
@@ -33,7 +33,7 @@
                         <%= link_to "View",  expense_type_expenses_path(expense_type) %>
                     </div>
                 </div>
-                <div class="col expense-type-links">
+                <div class="col-6 expense-type-links">
                     <div class="row">
                         <span class="text-muted mr-1">Budget</span> - <span class="ml-1">$<%=expense_type.budgets.sum(:amount)%></span>
                     </div>

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -1,4 +1,6 @@
-<%= render 'components/header', path: expense_type_expenses_path %>
+<div class="categories-header">
+    <%= render 'components/header', path: expense_type_expenses_path %>
+</div>
 <div class="row mx-auto flex-column">
     <div class="col my-3">
         <h5><%= expense.id ? "Update #{@expense_type.name} expense" : "Add a new #{@expense_type.name} expense"%></h5>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -1,63 +1,63 @@
 <div class="categories-header">
     <%= render 'components/header', path: expense_types_path %>
-    <h3 class="categories-text"">
-        Expenses
-</div>
-    </h3>
-<div class="calendar-main">
-<div class="row">
-    <% if @expenses.length.zero? %>
-    <div class="no-expense-container mx-auto mt-5">
-        <p>You do not have any expenses</p>
+    <div class="row">
+        <h3 class="categories-text  mx-auto">Expenses</h3>
     </div>
-    <%else%>
-    <div class="col mx-auto mt-3">
-        <div class="container">
-            <div class="row mb-3">
-                <div class="col-8">
-                    <% if @expense_type.budgets.sum(:amount) < @expense_type.expenses.sum(:amount)%>
-                    <div class="col expense-type-alert-lg px-3 py-1 mt-2">
-                        <span>You have overshot your expenses.</span>
+</div>
+<div class="calendar-main">
+    <div class="row">
+        <% if @expenses.length.zero? %>
+        <div class="no-expense-container mx-auto mt-5">
+            <p>You do not have any expenses</p>
+        </div>
+        <%else%>
+        <div class="col mx-auto mt-3">
+            <div class="container">
+                <div class="row mb-3">
+                    <div class="col-8">
+                        <% if @expense_type.budgets.sum(:amount) < @expense_type.expenses.sum(:amount)%>
+                        <div class="col expense-type-alert-lg px-3 py-1 mt-2">
+                            <span>You have overshot your expenses.</span>
+                        </div>
+                        <% end %>
                     </div>
-                    <% end %>
+                    <div class="col-4 ml-auto">
+                        <div class="row">
+                            <span class="text-muted mr-1">Actuals</span> - <span class="ml-1">$<%=@expense_type.expenses.sum(:amount)%></span>
+                        </div>
+                        <div class="row">
+                            <span class="text-muted mr-1">Budget</span> - <span class="ml-1">$<%=@expense_type.budgets.sum(:amount)%></span>
+                        </div>
+                    </div>
                 </div>
-                <div class="col-4 ml-auto">
-                    <div class="row">
-                        <span class="text-muted mr-1">Actuals</span> - <span class="ml-1">$<%=@expense_type.expenses.sum(:amount)%></span>
-                    </div>
-                    <div class="row">
-                        <span class="text-muted mr-1">Budget</span> - <span class="ml-1">$<%=@expense_type.budgets.sum(:amount)%></span>
-                    </div>
+                <div class="row">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Date</th>
+                                <th scope="col">Expense</th>
+                                <th scope="col">Amount</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <%@expenses.each do |expense|%>
+                            <tr style="margin-top: 20px;">
+                                <td class="text-muted"><%=expense.date.strftime("%m/%d/%Y")%></td>
+                                <td class="text-muted"><%=expense.description%></td>
+                                <td class="text-muted"><%=expense.amount%></td>
+                            </tr>
+                            <tr>
+                                <td colspan="5">
+                                    <%= link_to "Edit",edit_expense_type_expense_path(@expense_type, expense), class: "button button-sm primary-green" %>
+                                    <%= link_to "Delete",expense_type_expense_path(@expense_type, expense), method: :delete, class: "button button-sm secondary-pink" %>
+                                </td>
+                            </tr>
+                            <%end%>
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-            <div class="row">
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th scope="col">Date</th>
-                            <th scope="col">Expense</th>
-                            <th scope="col">Amount</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <%@expenses.each do |expense|%>
-                        <tr style="margin-top: 20px;">
-                            <td class="text-muted"><%=expense.date.strftime("%m/%d/%Y")%></td>
-                            <td class="text-muted"><%=expense.description%></td>
-                            <td class="text-muted"><%=expense.amount%></td>
-                        </tr>
-                        <tr>
-                            <td colspan="5">
-                                <%= link_to "Edit",edit_expense_type_expense_path(@expense_type, expense), class: "button button-sm primary-green" %>
-                                <%= link_to "Delete",expense_type_expense_path(@expense_type, expense), method: :delete, class: "button button-sm secondary-pink" %>
-                            </td>
-                        </tr>
-                        <%end%>
-                    </tbody>
-                </table>
             </div>
         </div>
+        <%end%>
     </div>
-    <%end%>
-</div>
-<%= render 'components/fab', path: new_expense_type_expense_path %>
+    <%= render 'components/fab', path: new_expense_type_expense_path %>

--- a/app/views/favourite_places/index.html.erb
+++ b/app/views/favourite_places/index.html.erb
@@ -1,19 +1,13 @@
-<div class="row header green pb-3">
-    <div class="container">
-        <div class="row my-3">
-            <%= link_to places_path do %>
-            <i class="fas fa-chevron-left white ml-4"></i>
-            <%end%>
+<div class="categories-header">
+    <%= render 'components/header', path: places_path %>
+    <div class="row">
+        <div class="col-2 mx-auto">
+            <%= image_tag('heart.svg', class: 'logo heart-logo') %>
         </div>
-        <div class="row">
-            <div class="col-2 mx-auto">
-                <%= image_tag('heart.svg', class: 'logo heart-logo') %>
-            </div>
-        </div>
-        <div class="row mt-3">
-            <div class="col mx-auto text-center">
-                <h5>Favourite places</h5>
-            </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col mx-auto text-center">
+            <h5>Favourite places</h5>
         </div>
     </div>
 </div>

--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -1,9 +1,9 @@
 <div class="categories-header">
     <%= render 'components/header', path: root_path %>
-    <h3 class="categories-text"">
-    Explore
-    </h3>
+    <div class="row">
+        <h3 class="categories-text  mx-auto"> Explore Cafes</h3>
+    </div>
 </div>
-<div class="places-main">
+<div class=" places-main">
     <%= render 'form', place: @place %>
 </div>

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -1,17 +1,13 @@
-<div class="row header pb-3 border">
-    <div class="container">
-        <div class="row my-3">
-            <%= render 'components/header', path: places_path, white_header: true %>
+<div class="categories-header blue">
+    <%= render 'components/header', path: places_path %>
+    <div class="row">
+        <div class="col-2 mx-auto">
+            <%= image_tag('coffee-cup.svg', class: 'logo cafe-logo') %>
         </div>
-        <div class="row">
-            <div class="col-2 mx-auto">
-                <%= image_tag('coffee-cup.svg', class: 'logo cafe-logo') %>
-            </div>
-        </div>
-        <div class="row mt-3">
-            <div class="col mx-auto text-center">
-                <h5><%= @location.name %></h5>
-            </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col mx-auto text-center">
+            <h5><%= @location.name %></h5>
         </div>
     </div>
 </div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -3,11 +3,11 @@
         <div class="col-8">
             <div class="calendar-heading d-flex justify-content-between py-2">
                 <%= link_to calendar.url_for_previous_view do%>
-                <i class="fas fa-backward"></i>
+                <i class="fas fa-backward mt-2"></i>
                 <%end%>
                 <h5 class="calendar-title"><%= t('date.month_names')[start_date.month] %></h5>
                 <%= link_to calendar.url_for_next_view do%>
-                <i class="fas fa-forward"></i>
+                <i class="fas fa-forward mt-2"></i>
                 <%end%>
             </div>
         </div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,9 +1,9 @@
 <div class="simple-calendar">
     <div class="row">
-        <div class="col-8">
+        <div class="col-9">
             <div class="calendar-heading  d-flex justify-content-between py-2">
                 <%= link_to calendar.url_for_previous_view do%>
-                <i class="fas fa-backward"></i>
+                <i class="fas fa-backward mt-2"></i>
                 <%end%>
                 <% if calendar.number_of_weeks == 1 %>
                 <h5 class="calendar-title">Week <%= calendar.week_number %></h5>
@@ -11,11 +11,11 @@
                 <h5 class="calendar-title">Week <%= calendar.week_number %> - <%= calendar.end_week %></h5>
                 <%end%>
                 <%= link_to calendar.url_for_next_view do%>
-                <i class="fas fa-forward"></i>
+                <i class="fas fa-forward mt-2"></i>
                 <%end%>
             </div>
         </div>
-        <div class="col-4 mt-2">
+        <div class="col-3 mt-2">
             <%= link_to "Month view", events_path(month:true)%>
         </div>
     </div>


### PR DESCRIPTION
- The actuals and budget texts were squishing together in iphone12. Fixed it
- Implemented uniform header styles across places, expenses, calendar and forms related to these features.